### PR TITLE
Add tests for Telegram auth verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "tail": "wrangler tail",
-    "test": "echo \"No tests yet\"",
+    "test": "node --test tests",
     "lint": "eslint functions docs/js"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "mongodb": "^5.8.0"
   },
   "devDependencies": {
-      "eslint": "^9.0.0",
+    "eslint": "^9.0.0",
     "wrangler": "^3.0.0"
   }
 }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { verifyTelegramWebAppData } from '../functions/utils/auth.js';
+
+test('verifyTelegramWebAppData returns user for valid hash', () => {
+  const botToken = 'test_token';
+  const user = { id: 123, first_name: 'Alice' };
+  const authDate = '123456';
+
+  const params = new URLSearchParams({
+    auth_date: authDate,
+    user: JSON.stringify(user)
+  });
+
+  const dataCheckString = Array.from(params.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+  const secretKey = crypto
+    .createHmac('sha256', 'WebAppData')
+    .update(botToken)
+    .digest();
+
+  const hash = crypto
+    .createHmac('sha256', secretKey)
+    .update(dataCheckString)
+    .digest('hex');
+
+  params.set('hash', hash);
+  const initData = params.toString();
+
+  const result = verifyTelegramWebAppData(initData, botToken);
+  assert.deepStrictEqual(result, user);
+});
+
+test('verifyTelegramWebAppData returns null for invalid hash', () => {
+  const botToken = 'test_token';
+  const user = { id: 123, first_name: 'Alice' };
+  const authDate = '123456';
+
+  const params = new URLSearchParams({
+    auth_date: authDate,
+    user: JSON.stringify(user),
+    hash: 'invalid'
+  });
+
+  const initData = params.toString();
+  const result = verifyTelegramWebAppData(initData, botToken);
+  assert.strictEqual(result, null);
+});
+


### PR DESCRIPTION
## Summary
- add tests validating `verifyTelegramWebAppData` for both valid and invalid hashes
- update package.json to run tests via Node's built-in test runner

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7d32b2488333a759fabb5ed623c0