### PR TITLE
Handle details parsing for Telegram bot

### DIFF
--- a/functions/telegram/bot.js
+++ b/functions/telegram/bot.js
@@ -420,7 +420,9 @@ export class Bot {
         await this.sendMessage(chatId, 'This movie has no file uploaded yet.');
       }
     } else {
-      const details = JSON.parse(selected.details || '{}');
+      const details = typeof selected.details === 'string'
+        ? JSON.parse(selected.details)
+        : (selected.details || {});
       const seasons = details.seasons || [];
       
       if (seasons.length === 0) {
@@ -461,7 +463,9 @@ export class Bot {
       }), { expirationTtl: 1800 });
 
     } else {
-      const details = JSON.parse(selected.details || '{}');
+      const details = typeof selected.details === 'string'
+        ? JSON.parse(selected.details)
+        : (selected.details || {});
       const seasons = details.seasons || [];
       
       if (seasons.length === 0) {


### PR DESCRIPTION
## Summary
- Safely parse `selected.details` as string or object when fetching a title
- Apply the same safe parsing in upload flow to avoid double parsing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f796a2d7483338cc3e10e6bf80930