### PR TITLE
Include file id in streaming tickets

### DIFF
--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -49,9 +49,9 @@ export async function handleApiRequest(request, env, path) {
       
       case 'watch':
         return await handleWatchApi(request, db, params, user);
-      
+
       case 'ticket':
-        return await handleTicketApi(request, env, params, user);
+        return await handleTicketApi(request, db, env, params, user);
       
       case 'channels':
         return await handleChannelsApi(request, db, params, user);
@@ -350,31 +350,53 @@ async function handleWatchApi(request, db, params, user) {
   };
 }
 
-async function handleTicketApi(request, env, params, user) {
+async function handleTicketApi(request, db, env, params, user) {
   const [action] = params;
-  
+
   if (action === 'create' && request.method === 'POST') {
     const { contentId, type, season, episode } = await request.json();
-    
+
+    let fileId = null;
+    if (type === 'movie') {
+      const movie = await db.collection('movies').findOne({ id: contentId });
+      fileId = movie?.file_id;
+    } else if (type === 'show') {
+      const ep = await db.collection('episodes').findOne({
+        show_id: contentId,
+        season_number: Number(season),
+        episode_number: Number(episode)
+      });
+      fileId = ep?.file_id;
+    }
+
+    if (!fileId) {
+      return {
+        body: JSON.stringify({ error: 'Content not found' }),
+        status: 404,
+        headers: { 'Content-Type': 'application/json' }
+      };
+    }
+
     // Generate unique ticket
     const ticketId = generateTicketId();
     const expiresAt = Date.now() + (6 * 60 * 60 * 1000); // 6 hours
-    
+
     const ticketData = {
       contentId,
       type,
       season,
       episode,
+      fileId,
       userId: user?.id || 'guest',
       expiresAt,
       createdAt: Date.now()
     };
-    
+
     // Store in KV
     await env.TICKETS.put(ticketId, JSON.stringify(ticketData), {
       expirationTtl: 6 * 60 * 60 // 6 hours in seconds
     });
-    
+
     return {
       body: JSON.stringify({
         ticket: ticketId,


### PR DESCRIPTION
## Summary
- attach file_id to streaming tickets on creation
- resolve ticket IDs during streaming with expiry checks and better errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f796b8fe08333b05347e169ac618b