### PR TITLE
Add channel streaming ticket endpoint

### DIFF
--- a/docs/channel-streaming.md
+++ b/docs/channel-streaming.md
@@ -1,0 +1,14 @@
+# Channel Streaming Flow
+
+This flow describes how a client obtains and uses a live channel stream.
+
+1. **List Channels**
+   - `GET /api/channels/list`
+   - Returns available channels and the current program for each.
+2. **Request Stream**
+   - `GET /api/channels/stream/{channelId}`
+   - Response contains current program metadata and a time-limited `streamUrl`.
+3. **Start Playback**
+   - Load the returned `streamUrl` (`/stream/{ticketId}`) in the media player.
+4. **Refresh When Needed**
+   - When the ticket expires or the program changes, repeat step 2 to obtain a new `streamUrl`.

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -2,7 +2,7 @@
 import { connectDB } from '../db/connection.js';
 import { verifyTelegramWebAppData } from '../utils/auth.js';
 import { handleChannelsApi } from './channels.js';
-import { createTicket } from './ticket.js';
+import { handleTicketApi } from './ticket.js';
 
 export async function handleApiRequest(request, env, path) {
   const db = await connectDB(env);
@@ -339,38 +339,6 @@ async function handleWatchApi(request, db, params, user) {
     
     return {
       body: JSON.stringify({ success: true }),
-      status: 200,
-      headers: { 'Content-Type': 'application/json' }
-    };
-  }
-
-  return {
-    body: JSON.stringify({ error: 'Invalid request' }),
-    status: 400,
-    headers: { 'Content-Type': 'application/json' }
-  };
-}
-
-async function handleTicketApi(request, env, params, user) {
-  const [action] = params;
-
-  if (action === 'create' && request.method === 'POST') {
-    const { contentId, type, season, episode } = await request.json();
-
-    const { ticketId, expiresAt, streamUrl } = await createTicket(env, {
-      contentId,
-      type,
-      season,
-      episode,
-      userId: user?.id || 'guest'
-    });
-
-    return {
-      body: JSON.stringify({
-        ticket: ticketId,
-        expiresAt,
-        streamUrl
-      }),
       status: 200,
       headers: { 'Content-Type': 'application/json' }
     };

--- a/functions/api/index.js
+++ b/functions/api/index.js
@@ -2,6 +2,7 @@
 import { connectDB } from '../db/connection.js';
 import { verifyTelegramWebAppData } from '../utils/auth.js';
 import { handleChannelsApi } from './channels.js';
+import { createTicket } from './ticket.js';
 
 export async function handleApiRequest(request, env, path) {
   const db = await connectDB(env);
@@ -52,9 +53,9 @@ export async function handleApiRequest(request, env, path) {
       
       case 'ticket':
         return await handleTicketApi(request, env, params, user);
-      
+
       case 'channels':
-        return await handleChannelsApi(request, db, params, user);
+        return await handleChannelsApi(request, db, params, user, env);
       
       default:
         return {
@@ -352,34 +353,23 @@ async function handleWatchApi(request, db, params, user) {
 
 async function handleTicketApi(request, env, params, user) {
   const [action] = params;
-  
+
   if (action === 'create' && request.method === 'POST') {
     const { contentId, type, season, episode } = await request.json();
-    
-    // Generate unique ticket
-    const ticketId = generateTicketId();
-    const expiresAt = Date.now() + (6 * 60 * 60 * 1000); // 6 hours
-    
-    const ticketData = {
+
+    const { ticketId, expiresAt, streamUrl } = await createTicket(env, {
       contentId,
       type,
       season,
       episode,
-      userId: user?.id || 'guest',
-      expiresAt,
-      createdAt: Date.now()
-    };
-    
-    // Store in KV
-    await env.TICKETS.put(ticketId, JSON.stringify(ticketData), {
-      expirationTtl: 6 * 60 * 60 // 6 hours in seconds
+      userId: user?.id || 'guest'
     });
-    
+
     return {
       body: JSON.stringify({
         ticket: ticketId,
         expiresAt,
-        streamUrl: `/stream/${ticketId}`
+        streamUrl
       }),
       status: 200,
       headers: { 'Content-Type': 'application/json' }
@@ -425,10 +415,4 @@ function formatTVShow(show) {
     genres: show.details?.genres || [],
     language: show.language
   };
-}
-
-function generateTicketId() {
-  return Array.from(crypto.getRandomValues(new Uint8Array(16)))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
 }

--- a/functions/api/ticket.js
+++ b/functions/api/ticket.js
@@ -26,3 +26,35 @@ export async function createTicket(env, data) {
     streamUrl: `/stream/${ticketId}`
   };
 }
+
+export async function handleTicketApi(request, env, params, user) {
+  const [action] = params;
+
+  if (action === 'create' && request.method === 'POST') {
+    const { contentId, type, season, episode } = await request.json();
+
+    const { ticketId, expiresAt, streamUrl } = await createTicket(env, {
+      contentId,
+      type,
+      season,
+      episode,
+      userId: user?.id || 'guest'
+    });
+
+    return {
+      body: JSON.stringify({
+        ticket: ticketId,
+        expiresAt,
+        streamUrl
+      }),
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    };
+  }
+
+  return {
+    body: JSON.stringify({ error: 'Invalid request' }),
+    status: 400,
+    headers: { 'Content-Type': 'application/json' }
+  };
+}

--- a/functions/api/ticket.js
+++ b/functions/api/ticket.js
@@ -1,0 +1,28 @@
+// functions/api/ticket.js
+
+export function generateTicketId() {
+  return Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function createTicket(env, data) {
+  const ticketId = generateTicketId();
+  const expiresAt = data.expiresAt || (Date.now() + 6 * 60 * 60 * 1000);
+  const ticketData = {
+    ...data,
+    expiresAt,
+    createdAt: Date.now()
+  };
+
+  const ttlSeconds = Math.ceil((expiresAt - Date.now()) / 1000);
+  await env.TICKETS.put(ticketId, JSON.stringify(ticketData), {
+    expirationTtl: ttlSeconds
+  });
+
+  return {
+    ticketId,
+    expiresAt,
+    streamUrl: `/stream/${ticketId}`
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable ticket helper and integrate into ticket and channels APIs
- expose `/channels/stream/:channelId` to generate streaming tickets and return stream URLs
- document client flow for acquiring and using channel streams

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f796c8ac88333a7f8d43d5cde8418