### PR TITLE
Add channel streaming ticket endpoint

### DIFF
--- a/docs/channel-streaming.md
+++ b/docs/channel-streaming.md
@@ -1,0 +1,14 @@
+# Channel Streaming Flow
+
+This flow describes how a client obtains and uses a live channel stream.
+
+1. **List Channels**
+   - `GET /api/channels/list`
+   - Returns available channels and the current program for each.
+2. **Request Stream**
+   - `GET /api/channels/stream/{channelId}`
+   - Response contains current program metadata and a time-limited `streamUrl`.
+3. **Start Playback**
+   - Load the returned `streamUrl` (`/stream/{ticketId}`) in the media player.
+4. **Refresh When Needed**
+   - When the ticket expires or the program changes, repeat step 2 to obtain a new `streamUrl`.

--- a/functions/api/ticket.js
+++ b/functions/api/ticket.js
@@ -1,0 +1,60 @@
+// functions/api/ticket.js
+
+export function generateTicketId() {
+  return Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function createTicket(env, data) {
+  const ticketId = generateTicketId();
+  const expiresAt = data.expiresAt || (Date.now() + 6 * 60 * 60 * 1000);
+  const ticketData = {
+    ...data,
+    expiresAt,
+    createdAt: Date.now()
+  };
+
+  const ttlSeconds = Math.ceil((expiresAt - Date.now()) / 1000);
+  await env.TICKETS.put(ticketId, JSON.stringify(ticketData), {
+    expirationTtl: ttlSeconds
+  });
+
+  return {
+    ticketId,
+    expiresAt,
+    streamUrl: `/stream/${ticketId}`
+  };
+}
+
+export async function handleTicketApi(request, env, params, user) {
+  const [action] = params;
+
+  if (action === 'create' && request.method === 'POST') {
+    const { contentId, type, season, episode } = await request.json();
+
+    const { ticketId, expiresAt, streamUrl } = await createTicket(env, {
+      contentId,
+      type,
+      season,
+      episode,
+      userId: user?.id || 'guest'
+    });
+
+    return {
+      body: JSON.stringify({
+        ticket: ticketId,
+        expiresAt,
+        streamUrl
+      }),
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    };
+  }
+
+  return {
+    body: JSON.stringify({ error: 'Invalid request' }),
+    status: 400,
+    headers: { 'Content-Type': 'application/json' }
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable ticket helper and integrate into ticket and channels APIs
- expose `/channels/stream/:channelId` to generate streaming tickets and return stream URLs
- document client flow for acquiring and using channel streams
- factor ticket endpoint handler into dedicated module and import from API entry to resolve merge conflict
- clarify 404 error message for unknown API resources

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f796c8ac88333a7f8d43d5cde8418