### PR TITLE
Add JWT auth for web clients

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -4,6 +4,7 @@ class SparrowFlix {
         this.tg = window.Telegram?.WebApp;
         // Point to your Cloudflare Workers API
         this.apiUrl = 'https://sparrowflix-dev.sparrowflix.workers.dev/api';
+        this.webToken = null;
         this.content = { movies: [], shows: [] };
         this.watchHistory = [];
         this.currentUser = null;
@@ -16,17 +17,27 @@ class SparrowFlix {
         if (this.tg) {
             this.tg.ready();
             this.tg.expand();
-            
+
             // Set theme
             if (this.tg.colorScheme === 'dark') {
                 document.body.classList.add('dark');
             }
-            
+
             // Get auth data
             const initData = this.tg.initData;
             if (initData) {
                 localStorage.setItem('tg-auth', initData);
             }
+        }
+
+        // Capture web token from URL or localStorage
+        const params = new URLSearchParams(window.location.search);
+        const token = params.get('token');
+        if (token) {
+            localStorage.setItem('web-token', token);
+            this.webToken = token;
+        } else {
+            this.webToken = localStorage.getItem('web-token');
         }
         
         // Load content
@@ -663,6 +674,12 @@ class SparrowFlix {
         const authData = localStorage.getItem('tg-auth');
         if (authData) {
             headers['X-Telegram-Init-Data'] = authData;
+        }
+
+        // Add web token if present
+        const token = this.webToken || localStorage.getItem('web-token');
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
         }
 
         const url = `${this.apiUrl}${endpoint}`;

--- a/functions/utils/jwt.js
+++ b/functions/utils/jwt.js
@@ -1,0 +1,47 @@
+// functions/utils/jwt.js
+// Simple JWT verification for web clients
+import crypto from 'crypto';
+
+function base64urlDecode(str) {
+  const pad = str.length % 4;
+  const normalized = str.replace(/-/g, '+').replace(/_/g, '/') +
+    (pad ? '='.repeat(4 - pad) : '');
+  return Buffer.from(normalized, 'base64').toString('utf8');
+}
+
+export function verifyWebToken(token, secret) {
+  try {
+    const [headerB64, payloadB64, signatureB64] = token.split('.');
+    if (!headerB64 || !payloadB64 || !signatureB64) {
+      return null;
+    }
+
+    const data = `${headerB64}.${payloadB64}`;
+    const expectedSig = crypto
+      .createHmac('sha256', secret)
+      .update(data)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    if (expectedSig !== signatureB64) {
+      return null;
+    }
+
+    const payloadJson = base64urlDecode(payloadB64);
+    const payload = JSON.parse(payloadJson);
+
+    if (payload.exp && Date.now() / 1000 > payload.exp) {
+      return null;
+    }
+
+    return payload;
+  } catch (err) {
+    console.error('JWT verification error:', err);
+    return null;
+  }
+}
+
+export default verifyWebToken;
+


### PR DESCRIPTION
## Summary
- support JWT web tokens alongside Telegram auth, removing ticket as a protected route
- verify JWT tokens via new `verifyWebToken` utility
- docs app now grabs web token and sends it with API requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689070da4c888333af89d5f336c1e2fc