### PR TITLE
Include fileId when creating streaming tickets

### DIFF
--- a/tests/ticket.test.js
+++ b/tests/ticket.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTicket } from '../functions/api/ticket.js';
+
+// Test that createTicket stores fileId from database lookup
+
+test('createTicket stores fileId in ticket data', async () => {
+  const fakeDB = {
+    collection: () => ({
+      findOne: async () => ({ file_id: 'file123' })
+    })
+  };
+
+  let stored;
+  const env = {
+    TICKETS: {
+      async put(key, value) {
+        stored = JSON.parse(value);
+      }
+    }
+  };
+
+  await createTicket(env, { contentId: '1', type: 'movie' }, fakeDB);
+
+  assert.strictEqual(stored.fileId, 'file123');
+});


### PR DESCRIPTION
## Summary
- fetch file_id for requested content during ticket creation
- store fileId in ticket data for streaming
- test that ticket creation records fileId

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689074fa9c1c8333b51b4953fb20ca35