### PR TITLE
feat: add basic react frontend scaffold

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SparrowFlix</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans">
+  <div id="root"></div>
+  <script type="module" src="./src/main.jsx"></script>
+</body>
+</html>

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,0 +1,17 @@
+import React from 'https://esm.sh/react@18';
+import { BrowserRouter, Routes, Route } from 'https://esm.sh/react-router-dom@6';
+import Header from './components/Header.jsx';
+import Home from './pages/Home.jsx';
+import Movies from './pages/Movies.jsx';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/movies" element={<Movies />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -1,0 +1,15 @@
+export async function apiRequest(endpoint, options = {}) {
+  const headers = { 'Content-Type': 'application/json', ...options.headers };
+  const authData = localStorage.getItem('tg-auth');
+  if (authData) headers['X-Telegram-Init-Data'] = authData;
+  const token = localStorage.getItem('web-token');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const response = await fetch(`https://sparrowflix-dev.sparrowflix.workers.dev/api${endpoint}`, {
+    ...options,
+    headers,
+  });
+  if (!response.ok) throw new Error(`API request failed: ${response.status}`);
+  return response.json();
+}
+
+export const getContent = () => apiRequest('/content');

--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -1,0 +1,20 @@
+import React from 'https://esm.sh/react@18';
+import { Link, useLocation } from 'https://esm.sh/react-router-dom@6';
+
+export default function Header() {
+  const location = useLocation();
+  const linkClasses = (path) =>
+    `px-3 py-2 ${location.pathname === path ? 'text-blue-500 font-semibold' : 'text-gray-700'}`;
+
+  return (
+    <header className="bg-white shadow-md">
+      <nav className="container mx-auto flex items-center justify-between p-4">
+        <Link to="/" className="text-xl font-bold">SparrowFlix</Link>
+        <div className="space-x-4">
+          <Link to="/" className={linkClasses('/')}>Home</Link>
+          <Link to="/movies" className={linkClasses('/movies')}>Movies</Link>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'https://esm.sh/react@18';
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+import App from './App.jsx';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/web/src/pages/Home.jsx
+++ b/web/src/pages/Home.jsx
@@ -1,0 +1,12 @@
+import React from 'https://esm.sh/react@18';
+import { Link } from 'https://esm.sh/react-router-dom@6';
+
+export default function Home() {
+  return (
+    <section className="p-8 text-center">
+      <h1 className="text-3xl font-bold mb-4">Welcome to Your Personal Cinema</h1>
+      <p className="mb-6">Stream your collection anywhere, anytime</p>
+      <Link to="/movies" className="bg-blue-500 text-white px-4 py-2 rounded">Start Watching</Link>
+    </section>
+  );
+}

--- a/web/src/pages/Movies.jsx
+++ b/web/src/pages/Movies.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'https://esm.sh/react@18';
+import { getContent } from '../api.js';
+
+export default function Movies() {
+  const [movies, setMovies] = useState([]);
+
+  useEffect(() => {
+    getContent().then(data => setMovies(data.movies || [])).catch(() => {});
+  }, []);
+
+  return (
+    <section className="p-4 grid grid-cols-2 md:grid-cols-4 gap-4">
+      {movies.map(movie => (
+        <div key={movie.id} className="bg-gray-200 rounded p-2 text-center">
+          <div className="font-semibold">{movie.title}</div>
+        </div>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold lightweight React frontend using CDN modules
- add tailwind-powered layout and navigation
- reuse existing API to render movie listings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68907e9490b483338bd8cc8abe095cb1