### PR TITLE
Add ticket-based video playback to web app

### DIFF
--- a/docs/web-app-usage.md
+++ b/docs/web-app-usage.md
@@ -1,0 +1,5 @@
+# Web App Usage
+
+1. Launch the web app inside Telegram or supply a JWT so requests include `X-Telegram-Init-Data` or `Authorization` headers.
+2. Before starting playback, send a POST request to `/api/ticket/create` and set the returned `streamUrl` as the `<video>` source.
+3. Ensure the worker is configured with `TICKETS` KV and `BOT_TOKEN` bindings before deployment.

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'https://esm.sh/react-router-dom@6'
 import Header from './components/Header.jsx';
 import Home from './pages/Home.jsx';
 import Movies from './pages/Movies.jsx';
+import Player from './pages/Player.jsx';
 
 export default function App() {
   return (
@@ -11,6 +12,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/movies" element={<Movies />} />
+        <Route path="/watch/:id" element={<Player />} />
       </Routes>
     </BrowserRouter>
   );

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -13,3 +13,8 @@ export async function apiRequest(endpoint, options = {}) {
 }
 
 export const getContent = () => apiRequest('/content');
+export const createTicket = (data) =>
+  apiRequest('/ticket/create', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });

--- a/web/src/pages/Movies.jsx
+++ b/web/src/pages/Movies.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'https://esm.sh/react@18';
+import { Link } from 'https://esm.sh/react-router-dom@6';
 import { getContent } from '../api.js';
 
 export default function Movies() {
@@ -12,7 +13,10 @@ export default function Movies() {
     <section className="p-4 grid grid-cols-2 md:grid-cols-4 gap-4">
       {movies.map(movie => (
         <div key={movie.id} className="bg-gray-200 rounded p-2 text-center">
-          <div className="font-semibold">{movie.title}</div>
+          <div className="font-semibold mb-2">{movie.title}</div>
+          <Link to={`/watch/${movie.id}`} className="text-blue-500">
+            Play
+          </Link>
         </div>
       ))}
     </section>

--- a/web/src/pages/Player.jsx
+++ b/web/src/pages/Player.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'https://esm.sh/react@18';
+import { useParams } from 'https://esm.sh/react-router-dom@6';
+import { createTicket } from '../api.js';
+
+export default function Player() {
+  const { id } = useParams();
+  const [streamUrl, setStreamUrl] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    createTicket({ contentId: id, type: 'movie' })
+      .then(({ streamUrl }) => {
+        setStreamUrl(`https://sparrowflix-dev.sparrowflix.workers.dev${streamUrl}`);
+      })
+      .catch((err) => setError(err.message));
+  }, [id]);
+
+  if (error) {
+    return <div className="p-4 text-red-500">{error}</div>;
+  }
+
+  return (
+    <section className="p-4">
+      {streamUrl ? (
+        <video
+          controls
+          autoPlay
+          className="w-full max-w-screen-md mx-auto"
+          src={streamUrl}
+        />
+      ) : (
+        <div>Loading...</div>
+      )}
+    </section>
+  );
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,7 @@ MONGODB_DATABASE = "sparrowflix"
 BOT_USERNAME = "sparrowflix_bot"
 MINI_APP_URL = "https://t.me/sparrowflix_bot/app"
 DEV_NO_AUTH = "true"
+BOT_TOKEN = "your-telegram-bot-token"
 
 [[env.development.d1_databases]]
 binding = "DB"
@@ -41,6 +42,7 @@ MONGODB_DATA_SOURCE = "Cluster0"
 MONGODB_DATABASE = "sparrowflix"
 BOT_USERNAME = "sparrowflix_bot"
 MINI_APP_URL = "https://t.me/sparrowflix_bot/app"
+BOT_TOKEN = "your-telegram-bot-token"
 
 [[env.production.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- request streaming tickets in the web client and play returned stream URL
- expose ticket creation helper and player page
- document required headers and worker bindings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b4a551b0833398d8f0be38f3e94b