### PR TITLE
feat: add global stop command

### DIFF
--- a/functions/telegram/bot.js
+++ b/functions/telegram/bot.js
@@ -30,6 +30,13 @@ export class Bot {
 
     console.log(`Received message: ${text} from chat: ${chatId}`);
 
+    // Master stop command - always takes precedence
+    if (text === '/stop') {
+      await this.env.FILEPATH_CACHE.delete(`state_${chatId}`);
+      await this.sendMessage(chatId, 'Bot stopped. Send /start to begin again.');
+      return;
+    }
+
     // First check if user is in a state-based flow
     const handled = await this.handleStateBasedMessage(message);
     if (handled) return;


### PR DESCRIPTION
## Summary
- honor /stop as a high-priority command in Telegram bot
- clear any active state and prompt users to restart

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b8747ef88333a72a04dac9b44679