### PR TITLE
Add start/stop process control for Telegram bot

### DIFF
--- a/functions/telegram/README.md
+++ b/functions/telegram/README.md
@@ -1,0 +1,12 @@
+# Telegram Bot
+
+This directory contains the Telegram bot code used by SparrowFlix.
+
+## Start/Stop behaviour
+
+The bot responds to `/start` and `/stop` for operational control:
+
+- **Node.js deployments** – `/stop` updates the bot status in `FILEPATH_CACHE` and then terminates the process using `process.exit(0)`. A supervisor (PM2, Docker, systemd, etc.) should restart the bot. After restart, `/start` clears the stopped flag and processing resumes.
+- **Serverless environments (e.g., Cloudflare Workers)** – These platforms don't support direct process management. In this mode the commands only toggle the flag in `FILEPATH_CACHE`. When stopped, all messages except `/start` receive a message that the bot is stopped and no updates are processed.
+
+Logs are emitted when the bot stops or starts to aid debugging.

--- a/functions/telegram/bot.js
+++ b/functions/telegram/bot.js
@@ -38,6 +38,14 @@ export class Bot {
       await this.env.FILEPATH_CACHE.put(statusKey, 'stopped', { expirationTtl: 86400 });
       await this.env.FILEPATH_CACHE.delete(`state_${chatId}`);
       await this.sendMessage(chatId, 'Bot stopped. Send /start to begin again.');
+      console.log(`Stop command received from chat ${chatId}`);
+      if (typeof process !== 'undefined' && typeof process.exit === 'function') {
+        console.log('Exiting process due to /stop command');
+        // Allow the message above to be sent before terminating
+        setTimeout(() => process.exit(0), 0);
+      } else {
+        console.log('Process exit not supported in this environment');
+      }
       return;
     }
 
@@ -55,6 +63,7 @@ export class Bot {
     if (text.startsWith('/start')) {
       await this.env.FILEPATH_CACHE.put(statusKey, 'active', { expirationTtl: 86400 });
       await this.env.FILEPATH_CACHE.delete(`state_${chatId}`);
+      console.log(`Start command received from chat ${chatId}`);
       await this.sendMainMenu(chatId);
     } else if (text.startsWith('/status')) {
       await this.sendMessage(chatId, isActive ? 'Bot is running.' : 'Bot is stopped.');

--- a/functions/telegram/bot.test.js
+++ b/functions/telegram/bot.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Bot } from './bot.js';
+
+class MockCache {
+  constructor() {
+    this.store = new Map();
+  }
+  async get(key) {
+    return this.store.get(key);
+  }
+  async put(key, value) {
+    this.store.set(key, value);
+  }
+  async delete(key) {
+    this.store.delete(key);
+  }
+}
+
+class TestBot extends Bot {
+  constructor(token, env) {
+    super(token, env);
+    this.sent = [];
+  }
+  async sendMessage(chatId, text, options = {}) {
+    this.sent.push({ chatId, text, options });
+  }
+}
+
+test('start and stop commands manage process and state', async () => {
+  const cache = new MockCache();
+  const env = { FILEPATH_CACHE: cache };
+  const bot = new TestBot('token', env);
+
+  let exitCode;
+  const originalExit = process.exit;
+  process.exit = (code) => {
+    exitCode = code;
+  };
+
+  await bot.handleMessage({ chat: { id: 1 }, text: '/start' });
+  assert.equal(await cache.get('bot_status_1'), 'active');
+
+  await bot.handleMessage({ chat: { id: 1 }, text: '/stop' });
+  // allow setTimeout inside handleMessage to fire
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(await cache.get('bot_status_1'), 'stopped');
+  assert.equal(exitCode, 0);
+
+  bot.sent = [];
+  await bot.handleMessage({ chat: { id: 1 }, text: 'hello' });
+  assert.equal(bot.sent[0].text, 'Bot is currently stopped. Send /start to begin.');
+
+  await bot.handleMessage({ chat: { id: 1 }, text: '/start' });
+  assert.equal(await cache.get('bot_status_1'), 'active');
+
+  process.exit = originalExit;
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "tail": "wrangler tail",
-    "test": "node --test tests",
+    "test": "node --test tests functions/telegram",
     "lint": "eslint functions docs/src"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- exit Node.js process on `/stop` and log start/stop reasons
- document start/stop behaviour for Node and serverless deployments
- test start/stop flow and process exit

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ee7bf4108333870bd1c72c2c4f48